### PR TITLE
Add ADLER32 checksum to zlib compressed output

### DIFF
--- a/HPIZ/Chunk.cs
+++ b/HPIZ/Chunk.cs
@@ -57,6 +57,9 @@ namespace HPIZ
                     default:
                         throw new InvalidOperationException("Unknow compression flavor");
                 }
+
+                WriteAdler32(bytesToCompress, compressedStream);
+
                 var compressedDataArray = compressedStream.ToArray(); //Change to stream
                 int checksum = ComputeChecksum(compressedDataArray); //Change to stream
 
@@ -112,5 +115,23 @@ namespace HPIZ
             return sum;
         }
 
+        private static void WriteAdler32(byte[] data, Stream output)
+        {
+            var s1 = 1;
+            var s2 = 0;
+            foreach (var b in data)
+            {
+                s1 = (s1 + b) % 65521;
+                s2 = (s2 + s1) % 65521;
+            }
+            var sum = (s2 * 65536) + s1;
+
+            var outputBytes = BitConverter.GetBytes(sum);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(outputBytes);
+            }
+            output.Write(outputBytes, 0, outputBytes.Length);
+        }
     }
 }


### PR DESCRIPTION
I heard from other modders in the TA community that archives created with HPIZ Archiver cannot be extracted using HPIView. For example in this thread:

https://www.tauniverse.com/forum/showthread.php?p=770622#post770622

I discovered that this is because HPIZ Archiver does not write the ADLER32 checksum at the end of its zlib-compressed data streams. This checksum is required at the end of an RFC1950 data stream -- see the RFC for details:

https://tools.ietf.org/html/rfc1950

When this checksum is not present, when decompressing with zlib, zlib does not consider the data to be finished when it reaches the end of its input. Tools based on JoeD's HPIUtil library consider this an error and fail to extract the data.

This patch implements writing this checksum.